### PR TITLE
Document and fix Standard System Utilities install

### DIFF
--- a/debos-recipes/scripts/install-standard.sh
+++ b/debos-recipes/scripts/install-standard.sh
@@ -1,2 +1,9 @@
 #!/bin/sh
+# The Standard System Utilities task that one sees in debian-installer
+# consist of packages with priority 'required', 'important' and 'standard'.
+# One can safely assume that 'required' packages are already installed.
+
+# Install packages with priority 'important'
 apt-get install $(dpkg-query -W -f'${Package}\t${Priority}\n' | awk '/important$/ {printf "%s ", $1}')
+# Install packages with priority 'standard'
+apt-get install $(dpkg-query -W -f'${Package}\t${Priority}\n' | awk '/standard$/ {printf "%s ", $1}')


### PR DESCRIPTION
The install-standard.sh script only installed packages with priority 'important', but not those with priority 'standard'.

As the Standard System Utilities is actually poorly documented (in general), document what it is in the comments of the script file.

Fixes: 0f1ae1d0df7ea90b76edf36a98a94b5e19141fe3