### PR TITLE
Add non-free-firmware archive area

### DIFF
--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -15,6 +15,7 @@ actions:
       - main
       - contrib
       - non-free
+      - non-free-firmware
     mirror: {{ $mirror }}
   - action: apt
     description: Install base packages


### PR DESCRIPTION
Since https://www.debian.org/vote/2022/vote_003 there is a new archive area: non-free-firmware
It hasn't happened yet, but there's a good chance that all non-free firmware will be moved there before the Bookworm release, so make sure it's available.