### PR TITLE
debos/overlays: add apt overlay for Experimental

### DIFF
--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -93,6 +93,11 @@ actions:
     destination: /etc/initramfs-tools/
 
   - action: overlay
+    description: Copy apt config for Experimental
+    source: overlays/apt/
+    destination: /etc/apt/
+
+  - action: overlay
     description: Copy kernel debs to /root
     source: overlays/linux-kernel/
     destination: /root/

--- a/debos-recipes/overlays/apt/preferences.d/50experimental
+++ b/debos-recipes/overlays/apt/preferences.d/50experimental
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=experimental
+Pin-Priority: 101

--- a/debos-recipes/overlays/apt/sources.list.d/experimental.list
+++ b/debos-recipes/overlays/apt/sources.list.d/experimental.list
@@ -1,0 +1,1 @@
+deb https://deb.debian.org/debian experimental main contrib non-free non-free-firmware


### PR DESCRIPTION
Debian will first release version 6.1~rc5 to Experimental and this kernel version should have all the needed parts to have a working Quartz64 device.

So add an overlay for APT which enables the Experimental release. Also add an APT preferences file which sets the Pin-Priority of Experimental to '101' (vs the default of '1').
By default, with a value of '1', packages from Experimental will not be upgraded automatically when a new version is released (to Experimental). With a value of '101' they will get upgraded.

Closes: #1