### PR TITLE
Enable unstable release

### DIFF
--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -93,6 +93,11 @@ actions:
     destination: /etc/initramfs-tools/
 
   - action: overlay
+    description: Copy apt config for Experimental
+    source: overlays/apt/
+    destination: /etc/apt/
+
+  - action: overlay
     description: Copy kernel debs to /root
     source: overlays/linux-kernel/
     destination: /root/

--- a/debos-recipes/overlays/apt/apt.conf.d/40default-release
+++ b/debos-recipes/overlays/apt/apt.conf.d/40default-release
@@ -1,0 +1,1 @@
+APT::Default-Release "bookworm";

--- a/debos-recipes/overlays/apt/preferences.d/50experimental
+++ b/debos-recipes/overlays/apt/preferences.d/50experimental
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=experimental
+Pin-Priority: 101

--- a/debos-recipes/overlays/apt/sources.list.d/experimental.list
+++ b/debos-recipes/overlays/apt/sources.list.d/experimental.list
@@ -1,0 +1,1 @@
+deb https://deb.debian.org/debian experimental main contrib non-free non-free-firmware

--- a/debos-recipes/overlays/apt/sources.list.d/sid.list
+++ b/debos-recipes/overlays/apt/sources.list.d/sid.list
@@ -1,0 +1,1 @@
+deb https://deb.debian.org/debian sid contrib non-free non-free-firmware


### PR DESCRIPTION
But also add a configuration file which makes 'Bookworm' the default.
To install something from Sid, do `apt install <pkg> -t sid`.

Without this configuration file, users would be running Sid as Sid has
higher versions of packages and higher versions 'win' when the
(Pin-)Priority is the same, which is (normally) the case with
Sid, Testing or Stable (all '500' by default).

Enabling 'Sid' is not (strictly) needed, but once 6.1.x is released *upstream*, then at some point the next 6.1.x Debian kernel release will be to Sid/Unstable. I can imagine that several of the (early) users of the images from this project would like to upgrade to that version when it becomes available. One needs to do that manually/explicitly because of the APT configuration file. One would then do `apt install linux-image-arm64 -t sid`.

When there are no Release Critical bugs found, then it should *transition* to Testing/Bookworm after 5 days.
Therefor this MR is optional. But it *could* be (quite) a while before that happens.


This is dependent (and based) on PR #7 (as that installs the basic overlay).