### PR TITLE
debos: Enable security repo

### DIFF
--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -17,6 +17,15 @@ actions:
       - non-free
       - non-free-firmware
     mirror: {{ $mirror }}
+
+  - action: run
+    description: Enable security repo
+    chroot: true
+    command: |
+      echo "" >> /etc/apt/sources.list
+      echo "# Bookworm security repo" >> /etc/apt/sources.list
+      echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware" >> /etc/apt/sources.list
+
   - action: apt
     description: Install base packages
     recommends: true


### PR DESCRIPTION
While Bookworm is still Testing, this repo will not do much.  
But once Bookworm becomes Stable, users will want security updates.