### PR TITLE
debos: Enable Bookworm updates repo

### DIFF
--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -87,6 +87,14 @@ actions:
       mkdir -p /etc/systemd/system/multi-user.target.wants
       ln -s /usr/lib/systemd/system/regen-openssh-keys.service /etc/systemd/system/multi-user.target.wants/regen-openssh-keys.service
 
+  - action: run
+    description: Enable Bookworm updates repo
+    chroot: true
+    command: |
+      echo "" >> /etc/apt/sources.list
+      echo "# Bookworm updates repo" >> /etc/apt/sources.list
+      echo "deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware" >> /etc/apt/sources.list
+
   - action: overlay
     description: Copy initramfs from Plebian
     source: overlays/initramfs-tools-plebian/


### PR DESCRIPTION
Important fixes to Bookworm when it is the Stable release, but which are not security fixes, are distributed via `bookworm-updates`. Users probably want that and not have to wait for a point release.

Note that the location within the file is rather random. I don't know if that has any effect.
I didn't insert it where I put the security repo (#9) as it would then cause a merge conflict. 
And `bookworm-updates` is not as important as the security repo is.