### PR TITLE
debos: Switch to Debian's kernel from Experimental

### DIFF
--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -111,20 +111,11 @@ actions:
     source: overlays/initramfs-tools-plebian/
     destination: /etc/initramfs-tools/
 
-  - action: overlay
-    description: Copy kernel debs to /root
-    source: overlays/linux-kernel/
-    destination: /root/
-
   - action: run
-    description: Install linux kernel packages
+    description: Install kernel from Experimental
     chroot: true
-    command: dpkg -i /root/*.deb
-
-  - action: run
-    description: Clean up debs in /root
-    chroot: true
-    command: rm /root/*.deb
+    command: |
+      apt-get install -y linux-image-arm64 -t experimental
 
   - action: run
     description: Set up u-boot default file


### PR DESCRIPTION
Now that a kernel with the needed code and commits has landed in Debian Experimental, switch to that (from a self-built kernel).

~~Draft as that still hasn't actually happened, but it is ready for review.~~

~~Do NOT merge it at this time! (which *Draft* hopefully automatically prevents)~~