### PR TITLE
debos/overlays/resizerootfs: Copy fsck.ext4 program into initramfs

### DIFF
--- a/debos-recipes/overlays/initramfs-tools-plebian/hooks/resizerootfs
+++ b/debos-recipes/overlays/initramfs-tools-plebian/hooks/resizerootfs
@@ -28,6 +28,9 @@ copy_exec /usr/bin/realpath
 copy_exec /usr/bin/tail
 copy_exec /usr/bin/test
 
+# from e2fsprogs
+copy_exec /sbin/fsck.ext4
+
 # from grep
 copy_exec /bin/grep
 


### PR DESCRIPTION
The initramfs now does contain `fsck`, but no longer `fsck.ext4` (?), so add it explicitly.