### PR TITLE
Further apt improvements

### DIFF
--- a/debos-recipes/overlays/apt/apt.conf.d/40default-release
+++ b/debos-recipes/overlays/apt/apt.conf.d/40default-release
@@ -1,1 +1,1 @@
-APT::Default-Release "bookworm";
+APT::Default-Release "/^bookworm(|-security|-updates)$/";

--- a/debos-recipes/overlays/apt/sources.list.d/sid.list
+++ b/debos-recipes/overlays/apt/sources.list.d/sid.list
@@ -1,1 +1,1 @@
-deb https://deb.debian.org/debian sid contrib non-free non-free-firmware
+deb https://deb.debian.org/debian sid main contrib non-free non-free-firmware


### PR DESCRIPTION
1. debos/overlays/apt: Enable Sid's 'main' too
2. debos/overlays/apt: Make '-security' and '-updates' part of Default-Release
    
    https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html#security-archive
    describes how to add bullseye-security and bullseye-updates to the
    Default-Release by using APT's support for Regular Expressions.
    
    Without this change, the package version in the normal Bookworm archive
    area has a higher APT priority then one in -security or -updates, which
    means it won't install (security) updates.
    With this change, the highest version wins, which is what we want.