### PR TITLE
debos: Use Bookworm's u-boot-menu

### DIFF
--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -127,13 +127,6 @@ actions:
     command: rm /root/*.deb
 
   - action: run
-    description: Install unstable u-boot-menu
-    chroot: true
-    command: |
-      apt-get update
-      apt-get install -y u-boot-menu -t unstable
-
-  - action: run
     description: Set up u-boot default file
     chroot: true
     script: scripts/set-u-boot-defaults.sh {{ $board }}


### PR DESCRIPTION
The version of u-boot-menu that's needed has transitioned to Testing aka Bookworm, so there's no need anymore to install Unstable's version. As u-boot-menu was already part of the 'main' software list, we can
remove the whole `action: run` that was added for Unstable's version.