### PR TITLE
Switch to unstable

### DIFF
--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -112,10 +112,10 @@ actions:
     destination: /etc/initramfs-tools/
 
   - action: run
-    description: Install kernel from Experimental
+    description: Install kernel from Sid
     chroot: true
     command: |
-      apt-get install -y linux-image-arm64 -t experimental
+      apt-get install -y linux-image-arm64 -t sid
 
   - action: run
     description: Set up u-boot default file

--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -35,7 +35,7 @@ actions:
       echo "deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware" >> /etc/apt/sources.list
 
   - action: overlay
-    description: Copy apt config for Sid and Experimental
+    description: Copy apt config for Sid
     source: overlays/apt/
     destination: /etc/apt/
 

--- a/debos-recipes/overlays/apt/preferences.d/50experimental
+++ b/debos-recipes/overlays/apt/preferences.d/50experimental
@@ -1,3 +1,0 @@
-Package: *
-Pin: release a=experimental
-Pin-Priority: 101

--- a/debos-recipes/overlays/apt/sources.list.d/experimental.list
+++ b/debos-recipes/overlays/apt/sources.list.d/experimental.list
@@ -1,1 +1,0 @@
-deb https://deb.debian.org/debian experimental main contrib non-free non-free-firmware


### PR DESCRIPTION
Now that the 6.1 kernel has been uploaded to Sid, let's use that.

Now that we don't need Experimental anymore, remove it.
On a proper Bookworm/Stable system, Experimental (and Sid and Testing)
should not be available. If the user would still want them, they should
add it themselves. And if it breaks, they get to keep all the pieces ;-)