### PR TITLE
Add initial firmware

### DIFF
--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -47,6 +47,7 @@ actions:
       - alsa-utils
       - bash-completion
       - bluetooth
+      - bluez-firmware
       - bzip2
       - ca-certificates
       - console-data
@@ -54,6 +55,7 @@ actions:
       - dbus-broker
       - e2fsprogs
       - file
+      - firmware-brcm80211
       - gawk
       - initramfs-tools
       - liblockfile-bin

--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -44,41 +44,40 @@ actions:
     update: true
     recommends: true
     packages:
-      - sudo
-      - openssh-server
-      - vim
-      - u-boot-menu
-      - initramfs-tools
-      - ca-certificates
-      - man-db
-      - console-setup
-      - console-data
-      - parted
-      - bash-completion
-      - xz-utils
-      - zstd
-      - ssh
-      - wget
-      - file
       - alsa-utils
+      - bash-completion
+      - bluetooth
+      - bzip2
+      - ca-certificates
+      - console-data
+      - console-setup
       - dbus-broker
-      - systemd-resolved
-      - systemd-timesyncd
+      - e2fsprogs
+      - file
+      - gawk
+      - initramfs-tools
+      - liblockfile-bin
+      - libnss-systemd
       - libpam-systemd
       - locales
-      - manpages
-      - pciutils
-      - bzip2
       - lsof
-      - traceroute
-      - libnss-systemd
-      - liblockfile-bin
-      - e2fsprogs
-      - parted
+      - man-db
+      - manpages
       - ncurses-term
-      - bluetooth
-      - gawk
       - network-manager
+      - openssh-server
+      - parted
+      - pciutils
+      - ssh
+      - sudo
+      - systemd-resolved
+      - systemd-timesyncd
+      - traceroute
+      - u-boot-menu
+      - vim
+      - wget
+      - xz-utils
+      - zstd
 
   - action: run
     description: Install standard packages


### PR DESCRIPTION
The first commit sorts the package list alphabetically so it's easier to find whether one is already included.

The second commit adds `bluez-firmware` and `firmware-brcm80211` to the image as those are almost certainly needed.
There's a good chance more are needed for wifi, but they can be added later is deemed necessary. 