### PR TITLE
Add wifi firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ preferred git workflow, please consult [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Short-term Goals
 
-* package the wireless firmware
 * generate images for post-Bookworm Debian
 * upstream kernel work: mainline a PWM driver for the GP7101 on the Blade
 * upstream devicetree work: properly fix USB on CM4IO

--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -59,6 +59,7 @@ actions:
       - dbus-broker
       - e2fsprogs
       - file
+      - firmware-brcm80211
       - gawk
       - initramfs-tools
       - liblockfile-bin

--- a/debos-recipes/debian-quartz64.yaml
+++ b/debos-recipes/debian-quartz64.yaml
@@ -49,41 +49,40 @@ actions:
     update: true
     recommends: true
     packages:
-      - sudo
-      - openssh-server
-      - vim
-      - u-boot-menu
-      - initramfs-tools
-      - ca-certificates
-      - man-db
-      - console-setup
-      - console-data
-      - parted
-      - bash-completion
-      - xz-utils
-      - zstd
-      - ssh
-      - wget
-      - file
       - alsa-utils
+      - bash-completion
+      - bluetooth
+      - bzip2
+      - ca-certificates
+      - console-data
+      - console-setup
       - dbus-broker
-      - systemd-resolved
-      - systemd-timesyncd
+      - e2fsprogs
+      - file
+      - gawk
+      - initramfs-tools
+      - liblockfile-bin
+      - libnss-systemd
       - libpam-systemd
       - locales
-      - manpages
-      - pciutils
-      - bzip2
       - lsof
-      - traceroute
-      - libnss-systemd
-      - liblockfile-bin
-      - e2fsprogs
-      - parted
+      - man-db
+      - manpages
       - ncurses-term
-      - bluetooth
-      - gawk
       - network-manager
+      - openssh-server
+      - parted
+      - pciutils
+      - ssh
+      - sudo
+      - systemd-resolved
+      - systemd-timesyncd
+      - traceroute
+      - u-boot-menu
+      - vim
+      - wget
+      - xz-utils
+      - zstd
 
   - action: run
     description: Install standard packages


### PR DESCRIPTION
This MR consists of the following 2 commits:

    debos: Sort package list alphabetically
    
    This way it's easier to see whether a package is already included.

--- 
    debos: Include firmware-brcm80211 to make wifi work
    
    Since version 20230210-2 the firmware-brcm80211 package includes the
    needed files to make wifi work on Model B, both 2.4Ghz and 5Ghz.
